### PR TITLE
[SDPA-3478] enable standalone url

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "drupal-module",
     "license": "GPL-2.0-or-later",
     "require": {
-        "dpc-sdp/tide_core": "^1.4.4",
+        "dpc-sdp/tide_core": "^1.5.0",
         "drupal/embed": "^1.0",
         "drupal/inline_entity_form": "^1.0-rc1",
         "drupal/svg_image": "^1.8",

--- a/dev-tools.sh
+++ b/dev-tools.sh
@@ -33,6 +33,6 @@
 # stable version.
 #
 # Uncomment and set the Dev-Tools's commit value and commit this change.
-# export GH_COMMIT=COMMIT_SHA
+export GH_COMMIT=a06d079ad232a38cf4cc39feaa4dd8f1df3fe9e2
 
 bash <(curl -L https://raw.githubusercontent.com/dpc-sdp/dev-tools/master/install?"$(date +%s)") "$@"

--- a/tests/behat/features/fields.feature
+++ b/tests/behat/features/fields.feature
@@ -14,7 +14,7 @@ Feature: Fields for different Media types
     And I should see an "label[for=edit-field-media-file-0-upload].form-required" element
     And I should see an "input#edit-field-media-file-0-upload" element
 
-    And I should see "Allowed types: pdf doc docx xls xlsx xlsm csv txt ppt pptx dot dotm dotx tiff tif eps zip." in the "#edit-field-media-file-0-upload--description" element
+    And I should see "Allowed types: pdf doc docx xls xlsx xlsm csv txt ppt pptx dot dotm dotx tiff tif eps zip." in the "#edit-field-media-file-0--description" element
 
     And I should see "License Type" in the "label[for=edit-field-license-type]" element
     And I should see an "select#edit-field-license-type" element
@@ -47,7 +47,7 @@ Feature: Fields for different Media types
     And I should see an "label[for=edit-field-media-file-0-upload].form-required" element
     And I should see an "input#edit-field-media-file-0-upload" element
 
-    And I should see "Allowed types: txt rtf doc docx ppt pptx xls xlsx pdf odf odg odp ods odt fodt fods fodp fodg key numbers pages tiff tif eps zip." in the "#edit-field-media-file-0-upload--description" element
+    And I should see "Allowed types: txt rtf doc docx ppt pptx xls xlsx pdf odf odg odp ods odt fodt fods fodp fodg key numbers pages tiff tif eps zip." in the "#edit-field-media-file-0--description" element
 
     And I should see "License Type" in the "label[for=edit-field-license-type]" element
     And I should see an "select#edit-field-license-type" element
@@ -78,7 +78,7 @@ Feature: Fields for different Media types
     And I should see "Image" in the "label[for=edit-field-media-image-0-upload]" element
     And I should see an "label[for=edit-field-media-image-0-upload].form-required" element
     And I should see an "input#edit-field-media-image-0-upload" element
-    And I should see "Allowed types: png gif jpg jpeg svg." in the "#edit-field-media-image-0-upload--description" element
+    And I should see "Allowed types: png gif jpg jpeg svg." in the "#edit-field-media-image-0--description" element
 
     And I attach the file "SampleJPGImage_50kbmb.jpg" to "Image"
     And I wait 80 seconds for AJAX to finish
@@ -123,7 +123,7 @@ Feature: Fields for different Media types
     And I should see an "label[for=edit-field-media-file-0-upload].form-required" element
     And I should see an "input#edit-field-media-file-0-upload" element
 
-    And I should see "Allowed types: mp4." in the "#edit-field-media-file-0-upload--description" element
+    And I should see "Allowed types: mp4." in the "#edit-field-media-file-0--description" element
 
     And I should see "Length" in the "label[for=edit-field-media-length-0-value]" element
     And I should not see an "label[for=edit-field-media-length-0-value].form-required" element
@@ -169,7 +169,7 @@ Feature: Fields for different Media types
     And I should see an "label[for=edit-field-media-file-0-upload].form-required" element
     And I should see an "input#edit-field-media-file-0-upload" element
 
-    And I should see "Allowed types: mp3." in the "#edit-field-media-file-0-upload--description" element
+    And I should see "Allowed types: mp3." in the "#edit-field-media-file-0--description" element
 
     And I should see "Length" in the "label[for=edit-field-media-length-0-value]" element
     And I should not see an "label[for=edit-field-media-length-0-value].form-required" element

--- a/tide_media.install
+++ b/tide_media.install
@@ -371,3 +371,13 @@ function tide_media_update_8008() {
     }
   }
 }
+
+/**
+ * Allowing standalone media URLs.
+ */
+function tide_media_update_8009() {
+  $config_factory = \Drupal::configFactory();
+  $media_config = $config_factory->getEditable('media.settings');
+  $media_config->set('standalone_url', TRUE);
+  $media_config->save();
+}


### PR DESCRIPTION
Jira: https://digital-engagement.atlassian.net/browse/SDPA-3478

# Issue:

>Drupal 8.7 introduced a change in the media module, namely it doesn’t by default provide a standalone URL (see screenshot). Changing the setting at https://nginx-php-content-vic-pr-738.lagoon.vicsdp.amazee.io/admin/config/media/media-settings allows the old behaviour.

- added a hook_update for fixing this issue.
- see https://github.com/dpc-sdp/content-vic-gov-au/pull/744