### PR TITLE
Fixes files listing issue.

### DIFF
--- a/src/Form/DeleteActionForm.php
+++ b/src/Form/DeleteActionForm.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\tide_media\Form;
 
-use Drupal\Core\File\Exception\FileNotExistsException;
+use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\file\Entity\File;
@@ -22,8 +22,24 @@ class DeleteActionForm extends FormBase {
   /**
    * {@inheritdoc}
    */
-  public function buildForm(array $form, FormStateInterface $form_state, int $fid = NULL, string $base_entity_id = NULL) {
+  public function buildForm(array $form, FormStateInterface $form_state, int $fid = NULL, string $redirect_info = NULL) {
     $file = File::load($fid);
+    $referenced = file_get_file_references($file, NULL, EntityStorageInterface::FIELD_LOAD_REVISION, '');
+    $media = NULL;
+    if (!empty($referenced)) {
+      foreach ($referenced as $data) {
+        foreach (array_keys($data) as $entity_type_id) {
+          if ($entity_type_id == 'media') {
+            foreach ($data[$entity_type_id] as $key => $value) {
+              $media = $value;
+            }
+          }
+        }
+      }
+    }
+    if ($media) {
+      $form_state->set('media', $media);
+    }
     $form['info'] = [
       '#markup' => t('Are you sure you want to delete the media %title ?', [
         '%title' => $file->getFilename(),
@@ -34,7 +50,7 @@ class DeleteActionForm extends FormBase {
       '#value' => 'Delete',
       '#button_type' => 'primary',
     ];
-    [$entity_type_id, $id] = explode('_', $base_entity_id);
+    [$entity_type_id, $id] = explode('_', $redirect_info);
     $form_state->set('file', $file);
     $form_state->set('redirect_route', 'entity.' . $entity_type_id . '.delete_form');
     $form_state->set('redirect_route_entity_type_id', $entity_type_id);
@@ -50,8 +66,14 @@ class DeleteActionForm extends FormBase {
       \Drupal::entityTypeManager()
         ->getStorage('file')
         ->delete([$form_state->get('file')]);
+      $media = $form_state->get('media');
+      if ($media) {
+        \Drupal::entityTypeManager()
+          ->getStorage('media')
+          ->delete([$media]);
+      }
     }
-    catch (FileNotExistsException $exception) {
+    catch (\Exception $exception) {
       watchdog_exception('tide_media', $exception);
     }
     try {

--- a/tide_media.routing.yml
+++ b/tide_media.routing.yml
@@ -7,9 +7,9 @@ tide_media.settings:
     _permission: 'administer media'
 
 tide_media.file.delete_action:
-  path: '/admin/media_files/deletion/{base_entity_id}/{fid}'
+  path: '/admin/media_files/deletion/{redirect_info}/{fid}'
   defaults:
     _form: '\Drupal\tide_media\Form\DeleteActionForm'
     _title: 'File deletion'
   requirements:
-    _permission: 'administer media'
+    _permission: 'access files overview'


### PR DESCRIPTION
### Jira
https://digital-engagement.atlassian.net/browse/SDPA-4950
https://digital-engagement.atlassian.net/browse/SDPSUP-2554

### Issue
the issue is rare, but it does exist. 
files some times attach to media revisions, but we do not use media revisions and we do not allow users to access media revisions. therefor users noticed that a file is `in use` but they cannot find it from `Full file deletion` page, because the file attaches to a revision of the media.

### Fix
find the file that attaches to a media revision, and show the file in the `Full file deletion` page. 

*includes* https://github.com/dpc-sdp/tide_media/pull/57