### PR TITLE
[SRM-223] Fixes page broken issue - updates entity_usage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
     "extra": {
         "patches": {
             "drupal/entity_usage": {
-                "Getting the base fields is not supported for entity type Block. - https://www.drupal.org/project/entity_usage/issues/3101451": "https://www.drupal.org/files/issues/2019-12-24/3101451-3.patch"
+                "Getting the base fields is not supported for entity type Block. - https://www.drupal.org/project/entity_usage/issues/3101451": "https://www.drupal.org/files/issues/2019-12-24/3101451-3.patch",
+                "fatal error after saveing the page not have a reuse entity. - https://www.drupal.org/project/entity_usage/issues/3098733#comment-14208957": "https://www.drupal.org/files/issues/2021-09-03/3098733-fatal-error-13.patch"
             }
         }
     }


### PR DESCRIPTION
### Jira
https://digital-engagement.atlassian.net/browse/SRM-223

### Issue
in the wysiwyg, somehow , it contains empty attributes, which causes page broken in saving.

```html
<p><a data-entity-substitution="" data-entity-type="" data-entity-uuid="" href="" id="" rel="" target="" title=""> </a></p>
```
it relates to entity_usage module.

### changes
1. add an open PR in drupalorg https://www.drupal.org/project/entity_usage/issues/3247583
2. patching entity_usage module. 