### PR TITLE
Updated tide_core version.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "GPL-2.0-or-later",
     "require": {
         "drupal/crop": "^2.1",
-        "dpc-sdp/tide_core": "3.0.0",
+        "dpc-sdp/tide_core": "^3.0.1",
         "drupal/embed": "^1.1",
         "drupal/focal_point": "^1.5",
         "drupal/inline_entity_form": "^1.0-rc1",


### PR DESCRIPTION
### Changes
As the tide_core version is locked, it causes issues whenever an updated gets pushed into tide_core and because of that it causes build failed sometime for this module and as well as for other modules where tide_media is a dependency module.