### PR TITLE
[SDPSUP-3966] Fix filter query on document and video picker

### DIFF
--- a/config/install/views.view.tide_media_browser.yml
+++ b/config/install/views.view.tide_media_browser.yml
@@ -790,7 +790,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          operator: '='
+          operator: contains
           value: ''
           group: 1
           exposed: true
@@ -1395,7 +1395,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          operator: '='
+          operator: contains
           value: ''
           group: 1
           exposed: true

--- a/tide_media.install
+++ b/tide_media.install
@@ -712,3 +712,13 @@ function tide_media_update_8041() {
     $config->setData($data)->save();
   }
 }
+
+/**
+ * Update filter operator on document and video pickers. [SDPSUP-3966]
+ */
+function tide_media_update_8042() {
+  $views_config = \Drupal::configFactory()->getEditable('views.view.tide_media_browser');
+  $views_config->set('display.document_browser.display_options.filters.name.operator', 'contains');
+  $views_config->set('display.embedded_video_browser.display_options.filters.name.operator', 'contains');
+  $views_config->save();
+}

--- a/tide_media.install
+++ b/tide_media.install
@@ -714,7 +714,7 @@ function tide_media_update_8041() {
 }
 
 /**
- * Update filter operator on document and video pickers. [SDPSUP-3966]
+ * Update filter operator on document and video pickers [SDPSUP-3966].
  */
 function tide_media_update_8042() {
   $views_config = \Drupal::configFactory()->getEditable('views.view.tide_media_browser');


### PR DESCRIPTION
JIRA Ticket: https://digital-engagement.atlassian.net/browse/SDPSUP-3966

Changed:
1) Update the filters for the name field on the Document and Video pickers to match based on "Contains" instead of "is equal to".