### PR TITLE
[SDPA-5443] Sanitise medie filenames

### DIFF
--- a/tide_media.module
+++ b/tide_media.module
@@ -13,6 +13,7 @@ use Drupal\Core\Link;
 use Drupal\Core\Url;
 use Drupal\Component\Render\FormattableMarkup;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\file\Entity\File;
 
 /**
  * Implements hook_views_pre_view().
@@ -118,8 +119,18 @@ function tide_media_form_alter(&$form, FormStateInterface $form_state, $form_id)
 /**
  * Implements hook_form_FORM_ID_alter().
  */
-function tide_media_form_media_form_alter(&$form, FormStateInterface $form_state) {
+function tide_media_form_media_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   $form['#attached']['library'][] = 'tide_media/media_form';
+  // Media files and documents only for sanitisation.
+  $allowed_form_ids = [
+    "media_file_add_form",
+    "media_file_edit_form",
+    "media_document_add_form",
+    "media_document_edit_form",
+  ];
+  if (in_array($form_id, $allowed_form_ids)) {
+    $form['actions']['submit']['#submit'][] = '_tide_media_file_document_submit';
+  }
 }
 
 /**
@@ -363,5 +374,33 @@ function tide_media_entity_bundle_field_info_alter(&$fields, EntityTypeInterface
     if (!empty($fields['field_media_transcript'])) {
       $fields['field_media_transcript']->addConstraint('media_field_constraint');
     }
+  }
+}
+
+/**
+ * Submit handler for sanitise filename.
+ */
+function _tide_media_file_document_submit($form, FormStateInterface &$form_state) {
+  $fid = $form_state->getValue('field_media_file');
+  if (!empty($fid)) {
+    $file = File::load($fid[0]['fids'][0]);
+    $filename_current = $file->getFilename();
+    // Rename filename.
+    $replacement = '-';
+    $tide_common_services = \Drupal::service('tide_core.common_services');
+    $filename_new = $tide_common_services->sanitiseFilename($filename_current, $replacement);
+    // Rename URI.
+    $uri = $file->getFileUri();
+    $new_uri = str_replace($filename_current, $filename_new, $uri);
+    // Rename filepath.
+    $stream_wrapper = \Drupal::service('stream_wrapper_manager')->getViaUri($uri);
+    $dir_path_current = $stream_wrapper->realpath();
+    $dir_path_new = str_replace($filename_current, $filename_new, $dir_path_current);
+    rename($dir_path_current, $dir_path_new);
+    // Complete the file.
+    $file->setFileUri($new_uri);
+    $file->setFilename($filename_new);
+    $file->setPermanent();
+    $file->save();
   }
 }


### PR DESCRIPTION
<!--
Please follow these rules:
1. SUBJECT: use format [SDPA-123] Verb in past tense with dot at the end.
   - This subject will be used as a commit message after PR is merged.
   - Verbs are usually one of these: Updated, Refactored, Removed, Changed, Added.
   - If there is no ticket - do not put [NOTICKET].

2. BODY: fill-in the template below

3. LABEL: Assign 'Needs review' label as soon as you ready to have this reviewed.

4. ASSIGNEE: Assign at least 2 reviewers.     

5. SLACK: Post a link to this PR to #developers channel.

No need to remove these lines - they are comments.
-->

**JIRA issue:** https://digital-engagement.atlassian.net/browse/SDPA-5443

### Changed

1. Replaced spaces in filename with hyphens using common service from tide_core.
2. Related to tide core PR https://github.com/dpc-sdp/tide_core/pull/298


### Screenshots

<!--
Provide as many screenshots as required to make reviewers understand what was changed.
-->

**Before sanitise, original filename was with spaces**
![159861164-4cfdd0ce-eac5-4420-b137-5c60945ce775](https://user-images.githubusercontent.com/67810118/160019418-49f9027f-c974-4f27-af83-559ca4041ba1.png)

**After uploaded, filename now is with hyphens.**
![159860846-7fe21e0b-eb5a-48e0-9a65-2c0df4216c83](https://user-images.githubusercontent.com/67810118/160019405-7a58fe26-96a7-467e-b9d5-7f2a51d3e459.png)
![159860796-41a60b38-d98e-4473-a937-f69a6b96e8ae](https://user-images.githubusercontent.com/67810118/160019414-0cf721bb-36ce-4ec6-96d2-b542925f643a.png)
![image](https://user-images.githubusercontent.com/67810118/160019425-e04c558b-7cfd-4f58-88a3-de51b89633fd.png)

**FE**
![image](https://user-images.githubusercontent.com/67810118/160019779-700f4e20-4bab-4e2e-bfd4-0809a3c74d49.png)

