### PR TITLE
Update tide_media_update_8041 hook

### DIFF
--- a/tide_media.install
+++ b/tide_media.install
@@ -669,8 +669,11 @@ function tide_media_update_8041() {
   foreach ($configs as $config => $type) {
     $config_read = _tide_read_config($config, $config_location, TRUE);
     $storage = \Drupal::entityTypeManager()->getStorage($type);
-    $config_entity = $storage->createFromStorageRecord($config_read);
-    $config_entity->save();
+    $id = substr($config, strrpos($config, '.') + 1);
+    if ($storage->load($id) == NULL) {
+      $config_entity = $storage->createFromStorageRecord($config_read);
+      $config_entity->save();
+    }
   }
   $update_configs = [
     'field.field.media.embedded_video.field_media_transcript' => 'field_config',


### PR DESCRIPTION
### Jira
https://digital-engagement.atlassian.net/browse/SRM-361

### Issue
```
[notice] Update started: tide_media_update_8041
>  [error]  'field_storage_config' entity with ID 'media.field_is_streamed' already exists.
```

### Change
1. check if the storage setting exists or not.