### PR TITLE
[SDPA-6049] Add RTL formatting in transcript pages.

### DIFF
--- a/config/install/core.entity_form_display.media.embedded_video.default.yml
+++ b/config/install/core.entity_form_display.media.embedded_video.default.yml
@@ -13,10 +13,12 @@ dependencies:
     - field.field.media.embedded_video.field_media_topic
     - field.field.media.embedded_video.field_media_transcript
     - field.field.media.embedded_video.field_media_video_embed_field
+    - field.field.media.embedded_video.field_metatags_rtl
     - media.type.embedded_video
   module:
     - content_moderation
     - field_group
+    - metatag
     - path
     - video_embed_field
 third_party_settings:
@@ -123,6 +125,14 @@ content:
     settings: {  }
     third_party_settings: {  }
     type: video_embed_field_textfield
+    region: content
+  field_metatags_rtl:
+    weight: 30
+    settings:
+      sidebar: true
+      use_details: true
+    third_party_settings: {  }
+    type: metatag_firehose
     region: content
   moderation_state:
     type: moderation_state_default

--- a/config/install/core.entity_view_display.media.embedded_video.default.yml
+++ b/config/install/core.entity_view_display.media.embedded_video.default.yml
@@ -13,8 +13,10 @@ dependencies:
     - field.field.media.embedded_video.field_media_topic
     - field.field.media.embedded_video.field_media_transcript
     - field.field.media.embedded_video.field_media_video_embed_field
+    - field.field.media.embedded_video.field_metatags_rtl
     - media.type.embedded_video
   module:
+    - metatag
     - text
     - user
     - video_embed_field
@@ -125,6 +127,13 @@ content:
       autoplay: false
     third_party_settings: {  }
     type: video_embed_field_video
+    region: content
+  field_metatags_rtl:
+    weight: 13
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: metatag_empty_formatter
     region: content
   uid:
     label: hidden

--- a/config/install/core.entity_view_display.media.embedded_video.embedded.yml
+++ b/config/install/core.entity_view_display.media.embedded_video.embedded.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.media.embedded_video.field_media_topic
     - field.field.media.embedded_video.field_media_transcript
     - field.field.media.embedded_video.field_media_video_embed_field
+    - field.field.media.embedded_video.field_metatags_rtl
     - media.type.embedded_video
   module:
     - video_embed_field
@@ -44,6 +45,7 @@ hidden:
   field_media_summary: true
   field_media_topic: true
   field_media_transcript: true
+  field_metatags_rtl: true
   name: true
   thumbnail: true
   uid: true

--- a/config/install/core.entity_view_display.media.embedded_video.embedded_with_transcript.yml
+++ b/config/install/core.entity_view_display.media.embedded_video.embedded_with_transcript.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.media.embedded_video.field_media_topic
     - field.field.media.embedded_video.field_media_transcript
     - field.field.media.embedded_video.field_media_video_embed_field
+    - field.field.media.embedded_video.field_metatags_rtl
     - media.type.embedded_video
   module:
     - video_embed_field
@@ -51,6 +52,7 @@ hidden:
   field_media_summary: true
   field_media_topic: true
   field_media_transcript: true
+  field_metatags_rtl: true
   name: true
   thumbnail: true
   uid: true

--- a/config/install/core.entity_view_display.media.embedded_video.media_browser_preview.yml
+++ b/config/install/core.entity_view_display.media.embedded_video.media_browser_preview.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.media.embedded_video.field_media_topic
     - field.field.media.embedded_video.field_media_transcript
     - field.field.media.embedded_video.field_media_video_embed_field
+    - field.field.media.embedded_video.field_metatags_rtl
     - image.style.thumbnail
     - media.type.embedded_video
   module:
@@ -52,4 +53,5 @@ hidden:
   field_media_topic: true
   field_media_transcript: true
   field_media_video_embed_field: true
+  field_metatags_rtl: true
   uid: true

--- a/config/install/field.field.media.embedded_video.field_metatags_rtl.yml
+++ b/config/install/field.field.media.embedded_video.field_metatags_rtl.yml
@@ -1,0 +1,21 @@
+uuid: 2f4321e2-f852-42ad-8f11-f088159226c6
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_metatags_rtl
+    - media.type.embedded_video
+  module:
+    - metatag
+id: media.embedded_video.field_metatags_rtl
+field_name: field_metatags_rtl
+entity_type: media
+bundle: embedded_video
+label: Metatags
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: metatag

--- a/config/install/field.storage.media.field_metatags_rtl.yml
+++ b/config/install/field.storage.media.field_metatags_rtl.yml
@@ -1,0 +1,19 @@
+uuid: 64665c54-7235-4f3a-bc32-3bb8b0032a30
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+    - metatag
+id: media.field_metatags_rtl
+field_name: field_metatags_rtl
+entity_type: media
+type: metatag
+settings: {  }
+module: metatag
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/tide_media.install
+++ b/tide_media.install
@@ -725,3 +725,52 @@ function tide_media_update_8042() {
   $views_config->set('display.embedded_video_browser.display_options.filters.name.operator', 'contains');
   $views_config->save();
 }
+
+/**
+ * Updates with new field_metatags_rtl field.
+ */
+function tide_media_update_8043() {
+  $configs = [
+    'field.storage.media.field_metatags_rtl' => 'field_storage_config',
+    'field.field.media.embedded_video.field_metatags_rtl' => 'field_config',
+  ];
+  module_load_include('inc', 'tide_core', 'includes/helpers');
+  $config_location = [drupal_get_path('module', 'tide_media') . '/config/install'];
+  // Check if field already exported to config/sync.
+  foreach ($configs as $config => $type) {
+    $config_read = _tide_read_config($config, $config_location, TRUE);
+    $storage = \Drupal::entityTypeManager()->getStorage($type);
+    $id = substr($config, strrpos($config, '.') + 1);
+    if ($storage->load($id) == NULL) {
+      $config_entity = $storage->createFromStorageRecord($config_read);
+      $config_entity->save();
+    }
+  }
+  $update_configs = [
+    'core.entity_view_display.media.embedded_video.default' => 'entity_view_display',
+    'core.entity_form_display.media.embedded_video.default' => 'entity_form_display',
+  ];
+  $config_settings = [
+    'dependencies',
+    'content',
+    'hidden',
+  ];
+  foreach ($update_configs as $update_config => $type) {
+    $config_read = _tide_read_config($update_config, $config_location, FALSE);
+    $config = \Drupal::configFactory()->getEditable($update_config);
+    if (!$config) {
+      continue;
+    }
+    $data = $config->getRawData();
+    foreach ($config_read as $key => $item) {
+      if (in_array($key, $config_settings)) {
+        NestedArray::setValue($data, [
+          $key,
+        ], NestedArray::getValue($config_read, [
+          $key,
+        ]));
+      }
+    }
+    $config->setData($data)->save();
+  }
+}


### PR DESCRIPTION
JIRA:
https://digital-engagement.atlassian.net/browse/SDPA-6049

Changes:
- Added new field Meta Tag RTL to fix transcript languages reading from Right to Left when in embedded video transcript.

Screenshots:
BE: "Metatags" tab
![image](https://user-images.githubusercontent.com/67810118/168752768-d2636ffd-1f34-4cbc-86b4-b54ca8f05b22.png)
Within the "Metatag" Tab, Field for "Content Language"
![image](https://user-images.githubusercontent.com/67810118/168752855-75995b82-7882-438b-a889-5ab898d9efe5.png)


FE
![image](https://user-images.githubusercontent.com/67810118/166193560-1685cced-52d2-4d31-90b9-84205dc82cca.png)
