### PR TITLE
[SDPAP-6346] Added file sanitisation function.

### DIFF
--- a/tide_media.module
+++ b/tide_media.module
@@ -13,7 +13,7 @@ use Drupal\Core\Link;
 use Drupal\Core\Url;
 use Drupal\Component\Render\FormattableMarkup;
 use Drupal\Core\Entity\EntityInterface;
-use Drupal\file\Entity\File;
+use Drupal\file\FileInterface;
 use Drupal\Core\Field\WidgetBase;
 
 /**
@@ -127,16 +127,6 @@ function tide_media_form_alter(&$form, FormStateInterface $form_state, $form_id)
  */
 function tide_media_form_media_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   $form['#attached']['library'][] = 'tide_media/media_form';
-  // Media files and documents only for sanitisation.
-  $allowed_form_ids = [
-    "media_file_add_form",
-    "media_file_edit_form",
-    "media_document_add_form",
-    "media_document_edit_form",
-  ];
-  if (in_array($form_id, $allowed_form_ids)) {
-    $form['actions']['submit']['#submit'][] = '_tide_media_file_document_submit';
-  }
 }
 
 /**
@@ -384,34 +374,6 @@ function tide_media_entity_bundle_field_info_alter(&$fields, EntityTypeInterface
 }
 
 /**
- * Submit handler for sanitise filename.
- */
-function _tide_media_file_document_submit($form, FormStateInterface &$form_state) {
-  $fid = $form_state->getValue('field_media_file');
-  if (!empty($fid)) {
-    $file = File::load($fid[0]['fids'][0]);
-    $filename_current = $file->getFilename();
-    // Rename filename.
-    $replacement = '-';
-    $tide_common_services = \Drupal::service('tide_core.common_services');
-    $filename_new = $tide_common_services->sanitiseFilename($filename_current, $replacement);
-    // Rename URI.
-    $uri = $file->getFileUri();
-    $new_uri = str_replace($filename_current, $filename_new, $uri);
-    // Rename filepath.
-    $stream_wrapper = \Drupal::service('stream_wrapper_manager')->getViaUri($uri);
-    $dir_path_current = $stream_wrapper->realpath();
-    $dir_path_new = str_replace($filename_current, $filename_new, $dir_path_current);
-    rename($dir_path_current, $dir_path_new);
-    // Complete the file.
-    $file->setFileUri($new_uri);
-    $file->setFilename($filename_new);
-    $file->setPermanent();
-    $file->save();
-  }
-}
-
-/**
  * Implements hook_field_widget_WIDGET_TYPE_form_alter().
  */
 function tide_media_field_widget_paragraphs_form_alter(&$element, FormStateInterface $form_state, $context) {
@@ -432,4 +394,31 @@ function tide_media_field_widget_paragraphs_form_alter(&$element, FormStateInter
       ];
     }
   }
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_presave() for file entities.
+ * Sanitises file names with spaces.
+ */
+function tide_media_file_presave(FileInterface $file) {
+  $bundle = $file->getMimeType();
+  $bun = $bundle;
+  $filename_current = $file->getFilename();
+  // Rename filename.
+  $replacement = '-';
+  // Helper to sanitise spaces in filename.
+  $tide_common_services = \Drupal::service('tide_core.common_services');
+  $filename_new = $tide_common_services->sanitiseFilename($filename_current, $replacement);
+  // Rename URI.
+  $uri = $file->getFileUri();
+  $new_uri = str_replace($filename_current, $filename_new, $uri);
+  // Rename filepath.
+  $stream_wrapper = \Drupal::service('stream_wrapper_manager')->getViaUri($uri);
+  $dir_path_current = $stream_wrapper->realpath();
+  $dir_path_new = str_replace($filename_current, $filename_new, $dir_path_current);
+  rename($dir_path_current, $dir_path_new);
+  // Complete the file.
+  $file->setFileUri($new_uri);
+  $file->setFilename($filename_new);
+  $file->setPermanent();
 }

--- a/tide_media.module
+++ b/tide_media.module
@@ -398,11 +398,9 @@ function tide_media_field_widget_paragraphs_form_alter(&$element, FormStateInter
 
 /**
  * Implements hook_ENTITY_TYPE_presave() for file entities.
- * Sanitises file names with spaces.
  */
 function tide_media_file_presave(FileInterface $file) {
-  $bundle = $file->getMimeType();
-  $bun = $bundle;
+  // Sanitises file names with spaces.
   $filename_current = $file->getFilename();
   // Rename filename.
   $replacement = '-';


### PR DESCRIPTION
### JIRA
https://digital-vic.atlassian.net/browse/SDPAP-6346

### Issue
The solution to sanitise file names that was added before was only limited to the document type media items that are only gets added by the media form. So other media items that gets added from different places e.g if user uses basic text to upload a media item, it will not sanitise the file name.
### Changes
1. Added file presave hook and during the presave it will sanitise the file name with spaces and replace necessary values.
2. This will get applied to all file uploads and update, not restricted to only media form. Gives more flexibility rather than targeting individual forms and media types. 
3. Removed the old sanitise function, which was only targeting media forms and only document bundle type.

### Related PRs - 
Test BE - https://nginx-php.pr-117.content-reference-sdp-vic-gov-au.sdp4.sdp.vic.gov.au/
Connected FE - https://app.pr-1232.ripple.sdp4.sdp.vic.gov.au/

### Test Video

[screen-capture.webm](https://user-images.githubusercontent.com/20810541/183624056-213339d8-a587-429c-80d3-32587b2fdce8.webm)

