### PR TITLE
[SW-2369] Fixes errors caused by file renaming

### DIFF
--- a/tide_media.module
+++ b/tide_media.module
@@ -15,6 +15,7 @@ use Drupal\Component\Render\FormattableMarkup;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\file\FileInterface;
 use Drupal\Core\Field\WidgetBase;
+use Drupal\Core\File\FileSystemInterface;
 
 /**
  * Implements hook_views_pre_view().
@@ -426,16 +427,13 @@ function tide_media_file_presave(FileInterface $file) {
   // Helper to sanitise spaces in filename.
   $tide_common_services = \Drupal::service('tide_core.common_services');
   $filename_new = $tide_common_services->sanitiseFilename($filename_current, $replacement);
-  // Rename URI.
-  $uri = $file->getFileUri();
-  $new_uri = str_replace($filename_current, $filename_new, $uri);
-  // Rename filepath.
-  $stream_wrapper = \Drupal::service('stream_wrapper_manager')->getViaUri($uri);
-  $dir_path_current = $stream_wrapper->realpath();
-  $dir_path_new = str_replace($filename_current, $filename_new, $dir_path_current);
-  rename($dir_path_current, $dir_path_new);
-  // Complete the file.
-  $file->setFileUri($new_uri);
-  $file->setFilename($filename_new);
-  $file->setPermanent();
+  if ($filename_new !== $filename_current) {
+    $uri = $file->getFileUri();
+    $path = pathinfo($uri);
+    /** @var \Drupal\Core\File\FileSystemInterface $file_service */
+    $file_service = \Drupal::service('file_system');
+    $file_service->move($file->getFileUri(), $path['dirname'] . '/' . $filename_new, FileSystemInterface::EXISTS_REPLACE);
+    $file->setFileUri($path['dirname'] . '/' . $filename_new);
+    $file->setFilename($filename_new);
+  }
 }


### PR DESCRIPTION
<!--
Please follow these rules:
1. SUBJECT: use format [SDPA-123] Verb in past tense with dot at the end.
   - This subject will be used as a commit message after PR is merged.
   - Verbs are usually one of these: Updated, Refactored, Removed, Changed, Added.
   - If there is no ticket - do not put [NOTICKET].

2. BODY: fill-in the template below

3. LABEL: Assign 'Needs review' label as soon as you ready to have this reviewed.

4. ASSIGNEE: Assign at least 2 reviewers.     

5. SLACK: Post a link to this PR to #developers channel.

No need to remove these lines - they are comments.
-->

**JIRA issue:** https://digital-vic.atlassian.net/browse/SDPAP-6646

### Description
In production there is a flag `make_unused_managed_files_temporary` that was turned on to remove inactive files or files without host when cron job runs.
For non-prod environments content-ref, content-vic does not have the flag turned on.
This fix is tested with both `make_unused_managed_files_temporary` turned on and off.

### Changed

1. Fixed errors cause by file renaming.

### Screenshots

<!--
Provide as many screenshots as required to make reviewers understand what was changed.
-->