### PR TITLE
[SDPAP-8094] Replacement of the deprecated function

### DIFF
--- a/config/install/field.field.media.audio.field_media_department.yml
+++ b/config/install/field.field.media.audio.field_media_department.yml
@@ -11,7 +11,7 @@ entity_type: media
 bundle: audio
 label: Department
 description: ''
-required: false
+required: true
 translatable: true
 default_value: {  }
 default_value_callback: ''

--- a/config/install/field.field.media.document.field_media_department.yml
+++ b/config/install/field.field.media.document.field_media_department.yml
@@ -11,7 +11,7 @@ entity_type: media
 bundle: document
 label: Department
 description: ''
-required: false
+required: true
 translatable: false
 default_value: {  }
 default_value_callback: ''

--- a/config/install/field.field.media.embedded_video.field_media_department.yml
+++ b/config/install/field.field.media.embedded_video.field_media_department.yml
@@ -11,7 +11,7 @@ entity_type: media
 bundle: embedded_video
 label: Department
 description: ''
-required: false
+required: true
 translatable: true
 default_value: {  }
 default_value_callback: ''

--- a/config/install/field.field.media.file.field_media_department.yml
+++ b/config/install/field.field.media.file.field_media_department.yml
@@ -11,7 +11,7 @@ entity_type: media
 bundle: file
 label: Department
 description: ''
-required: false
+required: true
 translatable: false
 default_value: {  }
 default_value_callback: ''

--- a/config/install/field.field.media.image.field_media_department.yml
+++ b/config/install/field.field.media.image.field_media_department.yml
@@ -11,7 +11,7 @@ entity_type: media
 bundle: image
 label: Department
 description: ''
-required: false
+required: true
 translatable: false
 default_value: {  }
 default_value_callback: ''

--- a/tide_media.module
+++ b/tide_media.module
@@ -394,9 +394,9 @@ function tide_media_entity_bundle_field_info_alter(&$fields, EntityTypeInterface
 }
 
 /**
- * Implements hook_field_widget_WIDGET_TYPE_form_alter().
+ * Implements hook_field_widget_single_element_WIDGET_TYPE_form_alter().
  */
-function tide_media_field_widget_paragraphs_form_alter(&$element, FormStateInterface $form_state, $context) {
+function tide_media_field_widget_single_element_paragraphs_form_alter(&$element, FormStateInterface $form_state, $context) {
   /** @var \Drupal\Core\Field\FieldItemListInterface $items */
   $items = $context['items'];
   $field_definition = $items->getFieldDefinition();


### PR DESCRIPTION
### Jira
https://digital-vic.atlassian.net/browse/SDPAP-8094

### Change
replaces `hook_field_widget_WIDGET_TYPE_form_alter` by `hook_field_widget_single_element_WIDGET_TYPE_form_alter`

### More details
https://www.drupal.org/node/3180429

> hook_field_widget_form_alter (hook_field_widget_WIDGET_TYPE_form_alter) was marked as deprecated and will be replaced by hook_field_widget_single_element_form_alter (hook_field_widget_single_element_WIDGET_TYPE_form_alter).

It seems that hook_field_widget_WIDGET_TYPE_form_alter is not functioning properly in Drupal 9.5.x due to the deprecation of functions.