### PR TITLE
updated ckeditor5 patch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "extra": {
         "patches": {
             "drupal/core": {
-                "Use CKEditor 5's native <ol type> and <ul type> UX - https://www.drupal.org/project/drupal/issues/3274635": "https://www.drupal.org/files/issues/2023-02-03/ckeditor-native-type-attr-on-ol-ul-ux-3274635-13.patch"
+                "Use CKEditor 5's native <ol type> and <ul type> UX - https://www.drupal.org/project/drupal/issues/3274635#comment-15507417": "https://www.drupal.org/files/issues/2024-03-21/ckeditor5_custom_patch_file.patch"
             },
             "drupal/video_embed_field": {
                 "Add support for Ckeditor 5 - https://www.drupal.org/project/video_embed_field/issues/3311063": "./patches/video_embed_field/video_embed_field_6.patch"


### PR DESCRIPTION
Update patch ckeditor 5 - Use CKEditor 5's native ol type and ul type UX
